### PR TITLE
libinih: Import from grisp1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /rtems/5
 build
 /demo*/b-*/
+external/libinih/b-imx7

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 	path = external/barebox
 	url = https://github.com/grisp/barebox.git
 	branch = v2020.03.0-GRiSP2
+[submodule "external/inih"]
+	path = external/libinih/inih
+	url = https://github.com/grisp/inih.git

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ RSB = $(MAKEFILE_DIR)/external/rtems-source-builder
 SRC_LIBBSD = $(MAKEFILE_DIR)/external/rtems-libbsd
 SRC_RTEMS = $(MAKEFILE_DIR)/external/rtems
 SRC_LIBGRISP = $(MAKEFILE_DIR)/external/libgrisp
+SRC_LIBINIH = $(MAKEFILE_DIR)/external/libinih
 SRC_BAREBOX = $(MAKEFILE_DIR)/external/barebox
 BUILD_BSP = $(MAKEFILE_DIR)/build/b-$(BSP)
 LIBBSD_BUILDSET = $(MAKEFILE_DIR)/src/libbsd.ini
@@ -34,7 +35,7 @@ help:
 	@grep -v grep $(MAKEFILE_LIST) | grep -A1 -h "#H" | sed -e '1!G;h;$$!d' -e 's/:[^\n]*\n/:\n\t/g' -e 's/#H//g' | grep -v -- --
 
 #H Build and install the complete toolchain, libraries, fdt and so on.
-install: submodule-update toolchain bootstrap bsp libbsd fdt bsp.mk libgrisp
+install: submodule-update toolchain bootstrap bsp libbsd fdt bsp.mk libgrisp libinih
 
 #H Update the submodules.
 submodule-update:
@@ -95,6 +96,10 @@ libbsd:
 #H Build and install libgrisp.
 libgrisp:
 	make RTEMS_ROOT=$(PREFIX) RTEMS_BSP=$(BSP) -C $(SRC_LIBGRISP) install
+
+#H Build and install libinih
+libinih:
+	make RTEMS_ROOT=$(PREFIX) RTEMS_BSP=$(BSP) -C $(SRC_LIBINIH) clean install
 
 #H Build the flattened device tree.
 fdt:

--- a/external/libinih/Makefile
+++ b/external/libinih/Makefile
@@ -1,0 +1,38 @@
+RTEMS_ROOT ?= $(PWD)/../rtems-install/rtems/5
+RTEMS_BSP ?= atsamv
+
+include $(RTEMS_ROOT)/make/custom/$(RTEMS_BSP).mk
+
+# inih uses a slightly odd cast. The way it is used, it should be no problem.
+# Therefore make an exception for this error.
+CFLAGS += -Wno-error=cast-qual
+
+# to support long lines:
+CFLAGS += -DINI_USE_STACK=0
+CFLAGS += -DINI_ALLOW_REALLOC=1
+CFLAGS += -DINI_MAX_LINE=1024*32
+
+LIB = $(BUILDDIR)/libinih.a
+LIB_PIECES = $(wildcard inih/*.c)
+LIB_OBJS = $(LIB_PIECES:%.c=$(BUILDDIR)/%.o)
+LIB_DEPS = $(LIB_PIECES:%.c=$(BUILDDIR)/%.d)
+
+all: $(BUILDDIR) $(LIB)
+
+install: all
+	mkdir -p $(PROJECT_INCLUDE)/inih
+	install -m 644 $(LIB) $(PROJECT_LIB)
+	install -m 644 inih/*.h $(PROJECT_INCLUDE)/inih
+
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
+	mkdir $(BUILDDIR)/inih
+
+$(LIB): $(LIB_OBJS)
+	$(AR) rcu $@ $^
+	$(RANLIB) $@
+
+clean:
+	rm -rf $(BUILDDIR)
+
+-include $(LIB_DEPS)


### PR DESCRIPTION
This imports the build for libinih from GRiSP1.

Closes #9.