### PR TITLE
CI: Add apt-get update before installing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash
         run:   |
           if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
             sudo apt-get install \
               build-essential \
               flex \


### PR DESCRIPTION
The CI is currently not working because a cached package isn't available any more. This patch adds the suggested "apt-get update" to the CI run.