### PR TITLE
Removing the OpenBLAS git dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,7 +31,3 @@
 	path = external/cryptoauthlib
 	url = https://github.com/grisp/cryptoauthlib
 	branch = GRiSP2
-[submodule "external/OpenBLAS"]
-	path = external/OpenBLAS
-	url = https://github.com/xianyi/OpenBLAS
-	tag = v0.3.23


### PR DESCRIPTION
Though OpenBLAS is not used anymore, it was sill cloned when building the toolchain. 